### PR TITLE
Fix  'obj[type]' const char*

### DIFF
--- a/src/WebConfig.cpp
+++ b/src/WebConfig.cpp
@@ -145,7 +145,7 @@ void WebConfig::addDescription(String parameter){
         if (obj.containsKey("name")) strlcpy(_description[_count].name,obj["name"],NAMELENGTH);
         if (obj.containsKey("label"))strlcpy(_description[_count].label,obj["label"],LABELLENGTH);
         if (obj.containsKey("type")) {
-          if (obj["type"].is<char *>()) {
+          if (obj["type"].is<const char *>()) {
             uint8_t t = 0;
             strlcpy(tmp,obj["type"],30);
             while ((t<INPUTTYPES) && (strcmp(tmp,inputtypes[t])!=0)) t++;


### PR DESCRIPTION


it was declared char and not const char...

Error I had..
.pio/libdeps/esp01/WebConfig/src/WebConfig.cpp:148:38:   required from here
.pio/libdeps/esp01/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:95:7: error: no type named 'type' in 'struct ArduinoJson6200_F1::enable_if<false, bool>'
.pio/libdeps/esp01/ArduinoJson/src/ArduinoJson/Variant/VariantRefBase.hpp:106:3: note: candidate: 'template<class T> typename ArduinoJson6200_F1::enable_if<(((! ArduinoJson6200_F1::ConverterNeedsWriteableRef<T>::value) && (! ArduinoJson6200_F1::is_same<T, char*>::value)) && (! ArduinoJson6200_F1::is_same<T, char>::value)), bool>::type ArduinoJson6200_F1::VariantRefBase<TDerived>::is() const [with T = T; TDerived = ArduinoJson6200_F1::MemberProxy<ArduinoJson6200_F1::JsonObject, const char*>]'